### PR TITLE
Autotrack fixes and improvements

### DIFF
--- a/src/main/java/algorithm/ImageDataProcessor.java
+++ b/src/main/java/algorithm/ImageDataProcessor.java
@@ -112,7 +112,7 @@ public class ImageDataProcessor {
     public boolean openConnection(VideoSource source, int deviceId){
         switch (source) {
             case LIVESTREAM:
-                imgSrc = new LivestreamSource(deviceId);
+                imgSrc = LivestreamSource.forDevice(deviceId);
                 break;
             case OPENIGTLINK:
                 imgSrc = new OIGTImageSource();

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -579,7 +579,12 @@ public class AutoTrackController implements Controller {
             }
 
             clicked_image_points.add(new Point3(x, y, 0.0));
-            clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).y_raw, trackingData.get(0).z_raw));
+            if(userPreferencesGlobal.getBoolean("exchangeYZ", false)) {
+                clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).z_raw, trackingData.get(0).y_raw));
+            }else {
+                clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).y_raw, trackingData.get(0).z_raw));
+            }
+
         }
     }
 }

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -285,7 +285,9 @@ public class AutoTrackController implements Controller {
             var max_num_points = 4; // 1
 
             var shifted_points = use3dTransformCheckBox.isSelected() ? applyTrackingTransformation3d(point.getX(), point.getY(), point.getZ()) : applyTrackingTransformation2d(point.getX(), point.getY(), point.getZ());
-            lastTrackingData.add(new ExportMeasurement(tool.getName(), point.getX(), point.getY(), point.getZ(), shifted_points[0], shifted_points[1], shifted_points[2]));
+            var x_normalized = shifted_points[0] / currentShowingImage.getWidth();
+            var y_normalized = shifted_points[1] / currentShowingImage.getHeight();
+            lastTrackingData.add(new ExportMeasurement(tool.getName(), point.getX(), point.getY(), point.getZ(), shifted_points[0], shifted_points[1], shifted_points[2], x_normalized, y_normalized));
 
             data.add(new XYChart.Data<>(shifted_points[0],shifted_points[1]));
             if(data.size() > max_num_points){

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -289,7 +289,8 @@ public class AutoTrackController implements Controller {
             var y_normalized = shifted_points[1] / currentShowingImage.getHeight();
             lastTrackingData.add(new ExportMeasurement(tool.getName(), point.getX(), point.getY(), point.getZ(), shifted_points[0], shifted_points[1], shifted_points[2], x_normalized, y_normalized));
 
-            data.add(new XYChart.Data<>(shifted_points[0],shifted_points[1]));
+            data.add(new XYChart.Data<>(shifted_points[0], shifted_points[1]));
+
             if(data.size() > max_num_points){
                 data.remove(0);
             }
@@ -442,7 +443,12 @@ public class AutoTrackController implements Controller {
         transformationMatrix.trackingPoints = new float[4][];
         for(int i = 0;i<clicked_image_points.size();i++){
             transformationMatrix.imagePoints[i] = new float[]{(float) clicked_image_points.get(i).x, (float) clicked_image_points.get(i).y, (float) clicked_image_points.get(i).z};
-            transformationMatrix.trackingPoints[i] = new float[]{(float) clicked_tracker_points.get(i).x, (float) clicked_tracker_points.get(i).y, (float) clicked_tracker_points.get(i).z};
+
+            if(userPreferencesGlobal.getBoolean("verticalFieldGenerator", false)) {
+                transformationMatrix.trackingPoints[i] = new float[]{(float) clicked_tracker_points.get(i).x, (float) clicked_tracker_points.get(i).z, (float) clicked_tracker_points.get(i).y};
+            }else {
+                transformationMatrix.trackingPoints[i] = new float[]{(float) clicked_tracker_points.get(i).x, (float) clicked_tracker_points.get(i).y, (float) clicked_tracker_points.get(i).z};
+            }
         }
 
         FileChooser fileChooser = new FileChooser();
@@ -522,7 +528,7 @@ public class AutoTrackController implements Controller {
         var matrix = transformationMatrix.getTransformMatOpenCvEstimated2d();
         var vector = new Mat(3,1, CvType.CV_64F);
         vector.put(0,0,x);
-        if(userPreferencesGlobal.getBoolean("exchangeYZ", false)){
+        if(userPreferencesGlobal.getBoolean("verticalFieldGenerator", false)){
             vector.put(1,0,z);
         }else{
             vector.put(1, 0, y);
@@ -579,7 +585,7 @@ public class AutoTrackController implements Controller {
             }
 
             clicked_image_points.add(new Point3(x, y, 0.0));
-            if(userPreferencesGlobal.getBoolean("exchangeYZ", false)) {
+            if(userPreferencesGlobal.getBoolean("verticalFieldGenerator", false)) {
                 clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).z_raw, trackingData.get(0).y_raw));
             }else {
                 clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).y_raw, trackingData.get(0).z_raw));

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -292,7 +292,6 @@ public class AutoTrackController implements Controller {
             var x_normalized = shifted_points[0] / currentShowingImage.getWidth();
             var y_normalized = shifted_points[1] / currentShowingImage.getHeight();
             lastTrackingData.add(new ExportMeasurement(tool.getName(), point.getX(), point.getY(), point.getZ(), shifted_points[0], shifted_points[1], shifted_points[2], x_normalized, y_normalized));
-            System.out.println("x: " + shifted_points[0] + " y: " + shifted_points[1] + " z: " + shifted_points[2]);
 
             data.add(new XYChart.Data<>(shifted_points[0], shifted_points[1]));
 

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -102,7 +102,6 @@ public class AutoTrackController implements Controller {
     private final ObservableList<Point3> clicked_image_points = FXCollections.observableArrayList();
     private final ObservableList<Point3> clicked_tracker_points = FXCollections.observableArrayList();
     private Mat cachedTransformMatrix = null;
-    private boolean useVerticalFieldGenerator = false;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
@@ -126,8 +125,6 @@ public class AutoTrackController implements Controller {
 
         videoImagePlot.setData(dataSeries);
         videoImagePlot.registerImageClickedHandler(this::onImageClicked);
-
-        useVerticalFieldGenerator = userPreferencesGlobal.getBoolean("verticalFieldGenerator", false);
 
         loadAvailableVideoDevicesAsync();
     }
@@ -535,7 +532,7 @@ public class AutoTrackController implements Controller {
         }
         var vector = new Mat(3,1, CvType.CV_64F);
 
-        if(useVerticalFieldGenerator){
+        if(userPreferencesGlobal.getBoolean("verticalFieldGenerator", false)){
             vector.put(0,0,z);
         }else{
             vector.put(0,0,x);
@@ -593,7 +590,7 @@ public class AutoTrackController implements Controller {
             }
 
             clicked_image_points.add(new Point3(x, y, 0.0));
-            if(useVerticalFieldGenerator) {
+            if(userPreferencesGlobal.getBoolean("verticalFieldGenerator", false)) {
                 clicked_tracker_points.add(new Point3(trackingData.get(0).z_raw, trackingData.get(0).y_raw, trackingData.get(0).x_raw));
             }else {
                 clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).y_raw, trackingData.get(0).z_raw));

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -272,7 +272,8 @@ public class AutoTrackController implements Controller {
                 series.getData().add(new XYChart.Data<>(0,0));  // Workaround to display legend
                 dataSeries.add(series);
                 series.getData().remove(0);
-                videoImagePlot.initSensorCurve(series);
+                // TODO: The sensor curve needs reworking (apply on transformed data and dont shrink)
+//                videoImagePlot.initSensorCurve(series);
             }
 
             var series = dataSeries.get(i);

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -520,7 +520,11 @@ public class AutoTrackController implements Controller {
         var matrix = transformationMatrix.getTransformMatOpenCvEstimated2d();
         var vector = new Mat(3,1, CvType.CV_64F);
         vector.put(0,0,x);
-        vector.put(1,0,y);
+        if(userPreferencesGlobal.getBoolean("exchangeYZ", false)){
+            vector.put(1,0,z);
+        }else{
+            vector.put(1, 0, y);
+        }
         vector.put(2,0,1);
 
         var pos_star = new Mat(2,1,CvType.CV_64F);
@@ -547,7 +551,7 @@ public class AutoTrackController implements Controller {
         vector.put(2,0,z);
         vector.put(3,0,1);
 
-        var pos_star = new Mat(3,1,CvType.CV_64F);
+        var pos_star = new Mat();
         Core.gemm(matrix, vector,1, new Mat(),1,pos_star);
         //Core.perspectiveTransform();  // Maybe try this?
         double[] out = new double[3];

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -534,12 +534,13 @@ public class AutoTrackController implements Controller {
             cachedTransformMatrix = transformationMatrix.getTransformMatOpenCvEstimated2d();
         }
         var vector = new Mat(3,1, CvType.CV_64F);
-        vector.put(0,0,x);
+
         if(useVerticalFieldGenerator){
-            vector.put(1,0,z);
+            vector.put(0,0,z);
         }else{
-            vector.put(1, 0, y);
+            vector.put(0,0,x);
         }
+        vector.put(1,0,y);
         vector.put(2,0,1);
 
         var pos_star = new Mat(2,1,CvType.CV_64F);
@@ -593,7 +594,7 @@ public class AutoTrackController implements Controller {
 
             clicked_image_points.add(new Point3(x, y, 0.0));
             if(useVerticalFieldGenerator) {
-                clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).z_raw, trackingData.get(0).y_raw));
+                clicked_tracker_points.add(new Point3(trackingData.get(0).z_raw, trackingData.get(0).y_raw, trackingData.get(0).x_raw));
             }else {
                 clicked_tracker_points.add(new Point3(trackingData.get(0).x_raw, trackingData.get(0).y_raw, trackingData.get(0).z_raw));
             }

--- a/src/main/java/controller/AutoTrackController.java
+++ b/src/main/java/controller/AutoTrackController.java
@@ -50,6 +50,7 @@ public class AutoTrackController implements Controller {
     private final Map<String, Integer> deviceIdMapping = new LinkedHashMap<>();
     private final Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
     private static final Preferences userPreferences = Preferences.userRoot().node("AutoTrack");
+    private static final Preferences userPreferencesGlobal = Preferences.userRoot().node("IGT_Settings");
     private final Logger logger = Logger.getLogger(this.getClass().getName());
 
     @FXML
@@ -110,6 +111,7 @@ public class AutoTrackController implements Controller {
         connectionProgressSpinner.setVisible(false);
         captureProgressSpinner.setVisible(false);
         sourceChoiceBox.getSelectionModel().selectedItemProperty().addListener(x -> changeVideoView());
+        sourceChoiceBox.setTooltip(new Tooltip("If you have multiple cameras connected, enable \"Search for more videos\" in the settings view to see all available devices"));
         captureRateComboBox.getItems().addAll("1000", "2000", "5000", "10000", "30000");
         captureRateComboBox.getSelectionModel().select(0);
 
@@ -165,7 +167,7 @@ public class AutoTrackController implements Controller {
     private void loadAvailableVideoDevicesAsync() {
         connectionProgressSpinner.setVisible(true);
         new Thread(() -> {
-            createDeviceIdMapping(true);
+            createDeviceIdMapping(userPreferencesGlobal.getBoolean("searchForMoreVideos", false));
             Platform.runLater(() -> {
                 sourceChoiceBox.getItems().addAll(deviceIdMapping.keySet());
                 if (!deviceIdMapping.isEmpty()) {
@@ -181,10 +183,10 @@ public class AutoTrackController implements Controller {
     /**
      * Tests out available video device ids. All devices that don't throw an error are added to the list.
      * This is bad style, but openCV does not offer to list available devices.
-     * @param fast Whether all available devices shall be enumerated. If set to true, there's a minimal performance gain.
+     * @param exhaustiveSearch Whether all available devices shall be enumerated. If set to false, there's a minimal performance gain.
      */
-    private void createDeviceIdMapping(boolean fast) {
-        if(fast){
+    private void createDeviceIdMapping(boolean exhaustiveSearch) {
+        if(!exhaustiveSearch){
             deviceIdMapping.put("Default Camera",0);
             return;
         }

--- a/src/main/java/controller/SettingsController.java
+++ b/src/main/java/controller/SettingsController.java
@@ -48,7 +48,7 @@ public class SettingsController implements Controller {
         tooltip.setWrapText(true);
         searchForMoreVideos.setTooltip(tooltip);
 
-        var exchangeYZPreference = userPreferences.getBoolean("exchangeYZ", false);
+        var exchangeYZPreference = userPreferences.getBoolean("verticalFieldGenerator", false);
         verticalFG.setSelected(exchangeYZPreference);
     }
 

--- a/src/main/java/controller/SettingsController.java
+++ b/src/main/java/controller/SettingsController.java
@@ -17,6 +17,7 @@ public class SettingsController implements Controller {
 
     @FXML public CheckBox consoleOutput;
     @FXML public CheckBox searchForMoreVideos;
+    @FXML public CheckBox exchangeYZ;
 
     @FXML
     private void changeConsoleOutput() {
@@ -27,6 +28,11 @@ public class SettingsController implements Controller {
     @FXML
     private void onSearchForMoreVideosClicked() {
         userPreferences.putBoolean("searchForMoreVideos", searchForMoreVideos.isSelected());
+    }
+
+    @FXML
+    private void onExchangeYZClicked(){
+        userPreferences.putBoolean("exchangeYZ", exchangeYZ.isSelected());
     }
 
     @Override
@@ -44,6 +50,9 @@ public class SettingsController implements Controller {
         var tooltip = new Tooltip("When enabled, the autotrack view will try to find and enumerate all video devices that are connected to the computer. This is helpful if you have more than one camera. However, this will increase the time needed before the view is ready");
         tooltip.setWrapText(true);
         searchForMoreVideos.setTooltip(tooltip);
+
+        var exchangeYZPreference = userPreferences.getBoolean("exchangeYZ", false);
+        exchangeYZ.setSelected(exchangeYZPreference);
     }
 
     @FXML

--- a/src/main/java/controller/SettingsController.java
+++ b/src/main/java/controller/SettingsController.java
@@ -2,41 +2,53 @@ package controller;
 
 import java.net.URL;
 import java.util.ResourceBundle;
+import java.util.prefs.Preferences;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ListView;
+import javafx.scene.control.Tooltip;
 import util.CustomLogger;
 
 public class SettingsController implements Controller {
+    private static final Preferences userPreferences = Preferences.userRoot().node("IGT_Settings");
 
-    private static final ObservableList<String> listItems = FXCollections.
-            observableArrayList();
-    @FXML public ListView<String> listView;
     @FXML public CheckBox consoleOutput;
+    @FXML public CheckBox searchForMoreVideos;
 
     @FXML
     private void changeConsoleOutput() {
         CustomLogger.changeConsoleOutput();
+        userPreferences.putBoolean("logToConsole", consoleOutput.isSelected());
+    }
+
+    @FXML
+    private void onSearchForMoreVideosClicked() {
+        userPreferences.putBoolean("searchForMoreVideos", searchForMoreVideos.isSelected());
     }
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         registerController();
-        listItems.addAll("Logging");
-        listView.setItems(listItems);
-        listView.getSelectionModel().select(0);
-        if (CustomLogger.isConsoleOn()) {
-            consoleOutput.setSelected(true);
+
+        var consolePreference = userPreferences.getBoolean("logToConsole", true);
+        consoleOutput.setSelected(consolePreference);
+        if (!CustomLogger.isConsoleOn() && consolePreference) {
+            CustomLogger.changeConsoleOutput();
         }
+
+        var searchForMoreVideosPreference = userPreferences.getBoolean("searchForMoreVideos", false);
+        searchForMoreVideos.setSelected(searchForMoreVideosPreference);
+        var tooltip = new Tooltip("When enabled, the autotrack view will try to find and enumerate all video devices that are connected to the computer. This is helpful if you have more than one camera. However, this will increase the time needed before the view is ready");
+        tooltip.setWrapText(true);
+        searchForMoreVideos.setTooltip(tooltip);
     }
 
     @FXML
     @Override
     public void close() {
-        listItems.clear();
         unregisterController();
     }
 }

--- a/src/main/java/controller/SettingsController.java
+++ b/src/main/java/controller/SettingsController.java
@@ -6,6 +6,7 @@ import java.util.prefs.Preferences;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import util.CustomLogger;
 
@@ -15,6 +16,9 @@ public class SettingsController implements Controller {
     @FXML public CheckBox consoleOutput;
     @FXML public CheckBox searchForMoreVideos;
     @FXML public CheckBox verticalFG;
+
+    @FXML public TextField videoWidth;
+    @FXML public TextField videoHeight;
 
     @FXML
     private void changeConsoleOutput() {
@@ -50,6 +54,25 @@ public class SettingsController implements Controller {
 
         var exchangeYZPreference = userPreferences.getBoolean("verticalFieldGenerator", false);
         verticalFG.setSelected(exchangeYZPreference);
+
+        var videoWidthPreference = userPreferences.getInt("videoWidth", 640);
+        videoWidth.setText(String.valueOf(videoWidthPreference));
+        var videoHeightPreference = userPreferences.getInt("videoHeight", 480);
+        videoHeight.setText(String.valueOf(videoHeightPreference));
+
+        videoWidth.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (!newValue.matches("\\d*")) {
+                videoWidth.setText(newValue.replaceAll("[^\\d]", ""));
+            }
+            userPreferences.putInt("videoWidth", Integer.parseInt(videoWidth.getText()));
+        });
+
+        videoHeight.textProperty().addListener((observable, oldValue, newValue) -> {
+            if (!newValue.matches("\\d*")) {
+                videoHeight.setText(newValue.replaceAll("[^\\d]", ""));
+            }
+            userPreferences.putInt("videoHeight", Integer.parseInt(videoHeight.getText()));
+        });
     }
 
     @FXML

--- a/src/main/java/controller/SettingsController.java
+++ b/src/main/java/controller/SettingsController.java
@@ -4,11 +4,8 @@ import java.net.URL;
 import java.util.ResourceBundle;
 import java.util.prefs.Preferences;
 
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
-import javafx.scene.control.ListView;
 import javafx.scene.control.Tooltip;
 import util.CustomLogger;
 
@@ -17,7 +14,7 @@ public class SettingsController implements Controller {
 
     @FXML public CheckBox consoleOutput;
     @FXML public CheckBox searchForMoreVideos;
-    @FXML public CheckBox exchangeYZ;
+    @FXML public CheckBox verticalFG;
 
     @FXML
     private void changeConsoleOutput() {
@@ -31,8 +28,8 @@ public class SettingsController implements Controller {
     }
 
     @FXML
-    private void onExchangeYZClicked(){
-        userPreferences.putBoolean("exchangeYZ", exchangeYZ.isSelected());
+    private void onVerticalFGClicked(){
+        userPreferences.putBoolean("verticalFieldGenerator", verticalFG.isSelected());
     }
 
     @Override
@@ -52,7 +49,7 @@ public class SettingsController implements Controller {
         searchForMoreVideos.setTooltip(tooltip);
 
         var exchangeYZPreference = userPreferences.getBoolean("exchangeYZ", false);
-        exchangeYZ.setSelected(exchangeYZPreference);
+        verticalFG.setSelected(exchangeYZPreference);
     }
 
     @FXML

--- a/src/main/java/controller/VideoController.java
+++ b/src/main/java/controller/VideoController.java
@@ -167,10 +167,10 @@ public class VideoController implements Controller {
         ivHeight.setText(Double.toString(height));
         ivWidth.setText(Double.toString(width));
 
-        topSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) height));
-        bottomSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) height));
-        rightSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) width));
-        leftSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) width));
+        topSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) height-1));
+        bottomSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) height-1));
+        rightSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) width-1));
+        leftSpinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(0,(int) width-1));
 
         // We don't need to remove the old listeners since the valueProperty will be a new one than before (because of the new ValueFactory)
         setCropListener();

--- a/src/main/java/inputOutput/ExportMeasurement.java
+++ b/src/main/java/inputOutput/ExportMeasurement.java
@@ -17,8 +17,12 @@ public class ExportMeasurement {
     public double y_raw;
     @Expose
     public double z_raw;
+    @Expose
+    public double x_normalized;
+    @Expose
+    public double y_normalized;
 
-    public ExportMeasurement(String toolName, double x_raw, double y_raw, double z_raw, double x_shifted, double y_shifted, double z_shifted) {
+    public ExportMeasurement(String toolName, double x_raw, double y_raw, double z_raw, double x_shifted, double y_shifted, double z_shifted, double x_normalized, double y_normalized) {
         this.toolName = toolName;
         this.x_raw = x_raw;
         this.y_raw = y_raw;
@@ -27,5 +31,8 @@ public class ExportMeasurement {
         this.x_shifted = x_shifted;
         this.y_shifted = y_shifted;
         this.z_shifted = z_shifted;
+
+        this.x_normalized = x_normalized;
+        this.y_normalized = y_normalized;
     }
 }

--- a/src/main/java/inputOutput/LivestreamSource.java
+++ b/src/main/java/inputOutput/LivestreamSource.java
@@ -1,5 +1,8 @@
 package inputOutput;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,13 +26,20 @@ public class LivestreamSource extends AbstractImageSource {
     private int deviceID = 0;
     private final Logger logger = Logger.getLogger(this.getClass().getName());
 
+    private static Map<Integer, LivestreamSource> instances = new TreeMap<>();
+    public static LivestreamSource forDevice(int id) {
+        if (!instances.containsKey(id)) {
+            instances.put(id, new LivestreamSource(id));
+        }
+        return instances.get(id);
+    }
     /**
      * constructs a new LivestreamSource object with the transmitted
      * <code>id</code>.
      *
      * @param id  describes which device is used
      */
-    public LivestreamSource(int id) {
+    private LivestreamSource(int id) {
         OpenCV.loadLocally();
         frameMatrix = new Mat();
         deviceID = id;
@@ -42,9 +52,12 @@ public class LivestreamSource extends AbstractImageSource {
      * @return whether the connection was successful or not
      */
     public boolean openConnection() {
+        if (vc != null && vc.isOpened()) {
+            logger.log(Level.INFO,"VideoCapture already initialized, reusing it.");
+            return true;
+        }
 
         vc = new VideoCapture(deviceID);
-
         if (vc.isOpened()) {
             logger.log(Level.INFO,"found VideoSource " + vc.toString());
             isConnected = true;

--- a/src/main/java/inputOutput/LivestreamSource.java
+++ b/src/main/java/inputOutput/LivestreamSource.java
@@ -62,8 +62,8 @@ public class LivestreamSource extends AbstractImageSource {
 
         vc = new VideoCapture(deviceID, Videoio.CAP_DSHOW);
         // This will set the resolution to the highest possible
-        vc.set(Videoio.CAP_PROP_FRAME_WIDTH, 1920);
-        vc.set(Videoio.CAP_PROP_FRAME_HEIGHT, 1080);
+        vc.set(Videoio.CAP_PROP_FRAME_WIDTH, 1280);
+        vc.set(Videoio.CAP_PROP_FRAME_HEIGHT, 720);
 
         if (vc.isOpened()) {
             logger.log(Level.INFO,"found VideoSource " + vc.toString());

--- a/src/main/java/inputOutput/LivestreamSource.java
+++ b/src/main/java/inputOutput/LivestreamSource.java
@@ -62,7 +62,7 @@ public class LivestreamSource extends AbstractImageSource {
             return true;
         }
 
-        vc = new VideoCapture(deviceID);
+        vc = new VideoCapture(deviceID, Videoio.CAP_DSHOW);
         // This will set the resolution to the highest possible
         vc.set(Videoio.CAP_PROP_FRAME_HEIGHT, desiredHeight);
         vc.set(Videoio.CAP_PROP_FRAME_WIDTH, desiredWidth);

--- a/src/main/java/inputOutput/LivestreamSource.java
+++ b/src/main/java/inputOutput/LivestreamSource.java
@@ -1,18 +1,19 @@
 package inputOutput;
 
-import java.util.HashMap;
+import nu.pattern.OpenCV;
+import org.opencv.core.Mat;
+import org.opencv.core.Size;
+import org.opencv.highgui.HighGui;
+import org.opencv.videoio.VideoCapture;
+import org.opencv.videoio.Videoio;
+
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
 
-import org.opencv.core.Mat;
-import org.opencv.highgui.HighGui;
-import org.opencv.videoio.VideoCapture;
-import org.opencv.videoio.Videoio;
-
-import nu.pattern.OpenCV;
+import static org.opencv.imgproc.Imgproc.resize;
 
 /**
  * provides the livestream footage from a webcam, ultrasound device or any other
@@ -22,7 +23,8 @@ import nu.pattern.OpenCV;
  *
  */
 public class LivestreamSource extends AbstractImageSource {
-
+    private final int desiredWidth = 640;
+    private final int desiredHeight = 480;
     private VideoCapture vc;
     private int deviceID = 0;
     private final Logger logger = Logger.getLogger(this.getClass().getName());
@@ -60,10 +62,10 @@ public class LivestreamSource extends AbstractImageSource {
             return true;
         }
 
-        vc = new VideoCapture(deviceID, Videoio.CAP_DSHOW);
+        vc = new VideoCapture(deviceID);
         // This will set the resolution to the highest possible
-        vc.set(Videoio.CAP_PROP_FRAME_WIDTH, 1280);
-        vc.set(Videoio.CAP_PROP_FRAME_HEIGHT, 720);
+        vc.set(Videoio.CAP_PROP_FRAME_HEIGHT, desiredHeight);
+        vc.set(Videoio.CAP_PROP_FRAME_WIDTH, desiredWidth);
 
         if (vc.isOpened()) {
             logger.log(Level.INFO,"found VideoSource " + vc.toString());
@@ -88,6 +90,8 @@ public class LivestreamSource extends AbstractImageSource {
         if (frameMatrix.empty()) {
             logger.log(Level.WARNING,"!!! Nothing captured from webcam !!!");
         }
+
+        resize(frameMatrix, frameMatrix, new Size(desiredWidth,desiredHeight));
 
         return frameMatrix;
     }

--- a/src/main/java/inputOutput/LivestreamSource.java
+++ b/src/main/java/inputOutput/LivestreamSource.java
@@ -90,8 +90,9 @@ public class LivestreamSource extends AbstractImageSource {
      * @return <code>isConnected = false</code>
      */
     public boolean closeConnection() {
-
-        vc.release();
+        if(vc != null) {
+            vc.release();
+        }
         HighGui.destroyAllWindows();
         exit = true;
         isConnected = false;

--- a/src/main/java/inputOutput/LivestreamSource.java
+++ b/src/main/java/inputOutput/LivestreamSource.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.prefs.Preferences;
 
 import org.opencv.core.Mat;
 import org.opencv.highgui.HighGui;
@@ -27,6 +28,8 @@ public class LivestreamSource extends AbstractImageSource {
     private final Logger logger = Logger.getLogger(this.getClass().getName());
 
     private static Map<Integer, LivestreamSource> instances = new TreeMap<>();
+
+    private static final Preferences userPreferencesGlobal = Preferences.userRoot().node("IGT_Settings");
     public static LivestreamSource forDevice(int id) {
         if (!instances.containsKey(id)) {
             instances.put(id, new LivestreamSource(id));
@@ -57,7 +60,11 @@ public class LivestreamSource extends AbstractImageSource {
             return true;
         }
 
-        vc = new VideoCapture(deviceID);
+        vc = new VideoCapture(deviceID, Videoio.CAP_DSHOW);
+        // This will set the resolution to the highest possible
+        vc.set(Videoio.CAP_PROP_FRAME_WIDTH, 1920);
+        vc.set(Videoio.CAP_PROP_FRAME_HEIGHT, 1080);
+
         if (vc.isOpened()) {
             logger.log(Level.INFO,"found VideoSource " + vc.toString());
             isConnected = true;

--- a/src/main/java/inputOutput/LivestreamSource.java
+++ b/src/main/java/inputOutput/LivestreamSource.java
@@ -23,8 +23,8 @@ import static org.opencv.imgproc.Imgproc.resize;
  *
  */
 public class LivestreamSource extends AbstractImageSource {
-    private final int desiredWidth = 640;
-    private final int desiredHeight = 480;
+    private int desiredWidth;
+    private int desiredHeight;
     private VideoCapture vc;
     private int deviceID = 0;
     private final Logger logger = Logger.getLogger(this.getClass().getName());
@@ -48,6 +48,9 @@ public class LivestreamSource extends AbstractImageSource {
         OpenCV.loadLocally();
         frameMatrix = new Mat();
         deviceID = id;
+
+        desiredWidth = userPreferencesGlobal.getInt("videoWidth", 640);
+        desiredHeight = userPreferencesGlobal.getInt("videoHeight", 480);
     }
 
     /**

--- a/src/main/java/util/CustomLogger.java
+++ b/src/main/java/util/CustomLogger.java
@@ -2,11 +2,14 @@ package util;
 
 import java.io.IOException;
 import java.util.logging.*;
+import java.util.prefs.Preferences;
 
 public class CustomLogger {
     private static FileHandler txtFile;
     private static SimpleFormatter formatter;
     private static boolean consoleOn = true;
+
+    private static final Preferences userPreferences = Preferences.userRoot().node("IGT_Settings");
 
     /**
      * Setup a log file in addition to standard console output
@@ -19,7 +22,9 @@ public class CustomLogger {
         txtFile.setFormatter(formatter);
 
         log.addHandler(txtFile);
-        log.addHandler(new ConsoleHandler());
+        if(userPreferences.getBoolean("logToConsole", true)) {
+            log.addHandler(new ConsoleHandler());
+        }
         log.setLevel(Level.FINE);
     }
 

--- a/src/main/resources/view/AutoTrackView.fxml
+++ b/src/main/resources/view/AutoTrackView.fxml
@@ -5,124 +5,125 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 <?import userinterface.PlottableImage?>
-<ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="Infinity" maxWidth="Infinity" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.AutoTrackController">
-   <content>
-      <VBox alignment="CENTER" maxHeight="Infinity" maxWidth="Infinity" spacing="20.0">
-         <children>
-            <PlottableImage fx:id="videoImagePlot" horizontalGridLinesVisible="false" maxHeight="Infinity" maxWidth="Infinity" verticalGridLinesVisible="false">
-               <xAxis>
-                  <NumberAxis autoRanging="false" lowerBound="-500.0" tickLabelsVisible="true" tickMarkVisible="true" minorTickVisible="false" side="BOTTOM" upperBound="500.0" />
-               </xAxis>
-               <yAxis>
-                  <NumberAxis autoRanging="false" lowerBound="-500.0" tickLabelsVisible="true" tickMarkVisible="true" minorTickVisible="false" side="LEFT" upperBound="500.0" />
-               </yAxis>
-            </PlottableImage>
-            <HBox alignment="CENTER" spacing="20.0">
-               <children>
-                  <TitledPane animated="false" collapsible="false" graphicTextGap="10.0" text="Connections" textAlignment="CENTER">
-                     <content>
-                        <VBox>
-                           <children>
-                              <HBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="20.0">
-                                 <children>
-                                    <Label text="Video Input" textAlignment="CENTER" />
-                                    <ChoiceBox fx:id="sourceChoiceBox" />
-                                 </children>
-                                 <padding>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                 </padding>
-                              </HBox>
-                              <HBox>
-                                 <CheckBox fx:id="trackingConnectedStatusBox" disable="true" mnemonicParsing="false" styleClass="red-green-checkbox"/>
-                                 <Label text="Trackingsource">
-                                    <padding>
-                                       <Insets left="5.0"/>
-                                    </padding>
-                                 </Label>
-                                 <padding>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                 </padding>
-                              </HBox>
-                              <BorderPane>
-                                 <center>
-                                    <Label text="Registration Matrix" textAlignment="CENTER">
-                                       <BorderPane.margin>
-                                          <Insets left="5.0" right="10.0" />
-                                       </BorderPane.margin></Label>
-                                 </center>
-                                 <left>
-                                    <CheckBox fx:id="regMatrixStatusBox" disable="true" mnemonicParsing="false" styleClass="red-green-checkbox" BorderPane.alignment="CENTER" />
-                                 </left>
-                                 <right>
-                                    <HBox alignment="CENTER_RIGHT">
-                                       <Button fx:id="regMatrixImportButton" alignment="CENTER_LEFT" mnemonicParsing="false" text="Import" BorderPane.alignment="CENTER" onAction="#on_importMatrix" />
-                                       <Button alignment="CENTER" mnemonicParsing="false" text="Reload" BorderPane.alignment="CENTER" onAction="#on_reloadMatrix" />
-                                       <Button fx:id="generateMatrixButton" alignment="CENTER_RIGHT" mnemonicParsing="false" text="Generate (0/4)" BorderPane.alignment="CENTER" onAction="#on_generateMatrix" />
-                                    </HBox>
-                                 </right>
-                                 <padding>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                 </padding>
-                              </BorderPane>
-                              <CheckBox fx:id="use3dTransformCheckBox" mnemonicParsing="false" text="Use 3D transformation">
-                                 <padding>
-                                    <Insets left="10.0" right="10.0" top="5.0"/>
-                                 </padding>
-                              </CheckBox>
-                           </children>
-                        </VBox>
-                     </content>
-                     <graphic>
-                        <ProgressIndicator fx:id="connectionProgressSpinner" prefHeight="15.0" prefWidth="15.0" />
-                     </graphic>
-                  </TitledPane>
-                  <TitledPane animated="false" collapsible="false" graphicTextGap="10.0" layoutX="10.0" layoutY="10.0" text="Capture Studio" textAlignment="CENTER">
-                     <content>
-                        <VBox>
-                           <children>
-                              <HBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="20.0">
-                                 <children>
-                                    <Label text="Output Path" textAlignment="CENTER" />
-                                    <TextField fx:id="outputPathField" editable="false" prefColumnCount="15" />
-                                    <Button fx:id="outputPathButton" mnemonicParsing="false" onAction="#on_browseOutputDirectory" text="Browse" />
-                                    <Button mnemonicParsing="false" onAction="#on_openOutputDirectory" text="Open Folder" />
-                                 </children>
-                                 <padding>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                 </padding>
-                              </HBox>
-                              <HBox alignment="CENTER_LEFT" layoutX="20.0" layoutY="20.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="20.0">
-                                 <children>
-                                    <Label text="Auto Capture Each" textAlignment="CENTER" />
-                                    <ComboBox fx:id="captureRateComboBox" editable="true" prefWidth="150.0" visibleRowCount="5" />
-                                    <Label text="ms" />
-                                 </children>
-                                 <padding>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                 </padding>
-                              </HBox>
-                              <HBox alignment="CENTER" layoutX="20.0" layoutY="20.0" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" spacing="50.0">
-                                 <padding>
-                                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                                 </padding>
-                                 <children>
-                                    <Button fx:id="singleCaptureButton" mnemonicParsing="false" onAction="#on_doSingleCapture" prefHeight="60.0" text="Capture Single Image" textAlignment="CENTER" wrapText="true" />
-                                    <ToggleButton fx:id="autoCaptureToggleButton" mnemonicParsing="false" onAction="#on_doAutoCapture" prefHeight="60.0" styleClass="green-toggle-button" text="Auto Capture" />
-                                 </children>
-                              </HBox>
-                           </children>
-                        </VBox>
-                     </content>
-                     <graphic>
-                        <ProgressIndicator fx:id="captureProgressSpinner" prefHeight="15.0" prefWidth="15.0" />
-                     </graphic>
-                  </TitledPane>
-               </children>
-            </HBox>
-         </children>
-         <padding>
-            <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
-         </padding>
-      </VBox>
-   </content>
+<ScrollPane fitToHeight="true" fitToWidth="true" maxHeight="Infinity" maxWidth="Infinity"
+            xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="controller.AutoTrackController">
+   <VBox alignment="CENTER" maxHeight="Infinity" maxWidth="Infinity" spacing="20.0">
+      <padding>
+         <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
+      </padding>
+      <PlottableImage fx:id="videoImagePlot" horizontalGridLinesVisible="false" maxHeight="Infinity"
+                      maxWidth="Infinity" verticalGridLinesVisible="false">
+         <xAxis>
+            <NumberAxis autoRanging="false" lowerBound="-500.0" tickLabelsVisible="true" tickMarkVisible="true"
+                        minorTickVisible="false" side="BOTTOM" upperBound="500.0"/>
+         </xAxis>
+         <yAxis>
+            <NumberAxis autoRanging="false" lowerBound="-500.0" tickLabelsVisible="true" tickMarkVisible="true"
+                        minorTickVisible="false" side="LEFT" upperBound="500.0"/>
+         </yAxis>
+      </PlottableImage>
+      <HBox alignment="CENTER" spacing="20.0">
+         <TitledPane animated="false" collapsible="false" graphicTextGap="10.0" text="Connections"
+                     textAlignment="CENTER">
+            <graphic>
+               <ProgressIndicator fx:id="connectionProgressSpinner" prefHeight="15.0" prefWidth="15.0"/>
+            </graphic>
+            <VBox>
+               <HBox alignment="CENTER_LEFT" maxHeight="1.7976931348623157E308"
+                     maxWidth="1.7976931348623157E308" spacing="20.0">
+                  <padding>
+                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                  </padding>
+                  <Label text="Video Input" textAlignment="CENTER"/>
+                  <ChoiceBox fx:id="sourceChoiceBox"/>
+               </HBox>
+               <HBox>
+                  <CheckBox fx:id="trackingConnectedStatusBox" disable="true" mnemonicParsing="false"
+                            styleClass="red-green-checkbox"/>
+                  <Label text="Trackingsource">
+                     <padding>
+                        <Insets left="5.0"/>
+                     </padding>
+                  </Label>
+                  <padding>
+                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                  </padding>
+               </HBox>
+               <BorderPane>
+                  <center>
+                     <Label text="Registration Matrix" textAlignment="CENTER">
+                        <BorderPane.margin>
+                           <Insets left="5.0" right="10.0"/>
+                        </BorderPane.margin>
+                     </Label>
+                  </center>
+                  <left>
+                     <CheckBox fx:id="regMatrixStatusBox" disable="true" mnemonicParsing="false"
+                               styleClass="red-green-checkbox" BorderPane.alignment="CENTER"/>
+                  </left>
+                  <right>
+                     <HBox alignment="CENTER_RIGHT">
+                        <Button fx:id="regMatrixImportButton" alignment="CENTER_LEFT"
+                                mnemonicParsing="false" text="Import" BorderPane.alignment="CENTER"
+                                onAction="#on_importMatrix"/>
+                        <Button alignment="CENTER" mnemonicParsing="false" text="Reload"
+                                BorderPane.alignment="CENTER" onAction="#on_reloadMatrix"/>
+                        <Button fx:id="generateMatrixButton" alignment="CENTER_RIGHT"
+                                mnemonicParsing="false" text="Generate (0/4)" BorderPane.alignment="CENTER"
+                                onAction="#on_generateMatrix"/>
+                     </HBox>
+                  </right>
+                  <padding>
+                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                  </padding>
+               </BorderPane>
+               <CheckBox fx:id="use3dTransformCheckBox" mnemonicParsing="false"
+                         text="Use 3D transformation">
+                  <padding>
+                     <Insets left="10.0" right="10.0" top="5.0"/>
+                  </padding>
+               </CheckBox>
+            </VBox>
+         </TitledPane>
+         <TitledPane animated="false" collapsible="false" graphicTextGap="10.0" layoutX="10.0" layoutY="10.0"
+                     text="Capture Studio" textAlignment="CENTER">
+            <graphic>
+               <ProgressIndicator fx:id="captureProgressSpinner" prefHeight="15.0" prefWidth="15.0"/>
+            </graphic>
+            <VBox>
+               <HBox alignment="CENTER_LEFT" spacing="20.0">
+                  <padding>
+                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                  </padding>
+                  <Label text="Output Path" textAlignment="CENTER"/>
+                  <TextField fx:id="outputPathField" editable="false" prefColumnCount="15"/>
+                  <Button fx:id="outputPathButton" mnemonicParsing="false"
+                          onAction="#on_browseOutputDirectory" text="Browse"/>
+                  <Button mnemonicParsing="false" onAction="#on_openOutputDirectory" text="Open Folder"/>
+               </HBox>
+               <HBox alignment="CENTER_LEFT" layoutX="20.0" layoutY="20.0" spacing="20.0">
+                  <padding>
+                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                  </padding>
+                  <Label text="Auto Capture Each" textAlignment="CENTER"/>
+                  <ComboBox fx:id="captureRateComboBox" editable="true" prefWidth="150.0"
+                            visibleRowCount="5"/>
+                  <Label text="ms"/>
+               </HBox>
+               <HBox alignment="CENTER" layoutX="20.0" layoutY="20.0" spacing="50.0">
+                  <padding>
+                     <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                  </padding>
+                  <Button fx:id="singleCaptureButton" mnemonicParsing="false"
+                          onAction="#on_doSingleCapture" prefHeight="60.0" text="Capture Single Image"
+                          textAlignment="CENTER" wrapText="true"/>
+                  <ToggleButton fx:id="autoCaptureToggleButton" mnemonicParsing="false"
+                                onAction="#on_doAutoCapture" prefHeight="60.0"
+                                styleClass="green-toggle-button" text="Auto Capture"/>
+               </HBox>
+            </VBox>
+         </TitledPane>
+      </HBox>
+   </VBox>
 </ScrollPane>

--- a/src/main/resources/view/MainView.fxml
+++ b/src/main/resources/view/MainView.fxml
@@ -16,67 +16,47 @@
             fx:controller="controller.MainController">
     <top>
         <MenuBar>
-            <menus>
-                <Menu mnemonicParsing="false" text="File">
-                    <items>
-                        <MenuItem mnemonicParsing="false" onAction="#openSettings" text="Settings"/>
-                        <SeparatorMenuItem mnemonicParsing="false"/>
-                        <MenuItem mnemonicParsing="false" onAction="#close" text="Close"/>
-                    </items>
+            <Menu mnemonicParsing="false" text="File">
+                <MenuItem mnemonicParsing="false" onAction="#openSettings" text="Settings"/>
+                <SeparatorMenuItem mnemonicParsing="false"/>
+                <MenuItem mnemonicParsing="false" onAction="#close" text="Close"/>
+            </Menu>
+            <Menu mnemonicParsing="false" text="Window">
+                <Menu mnemonicParsing="false" text="Show View">
+                    <MenuItem mnemonicParsing="false" onAction="#openMeasurementView" text="Measurement"/>
+                    <MenuItem mnemonicParsing="false" onAction="#openThrombectomyView" text="Thrombectomy"/>
+                    <MenuItem mnemonicParsing="false" onAction="#openAutoTrackView" text="AutoTrack"/>
                 </Menu>
-                <Menu mnemonicParsing="false" text="Window">
-                    <items>
-                        <Menu mnemonicParsing="false" text="Show View">
-                            <items>
-                                <MenuItem mnemonicParsing="false" onAction="#openMeasurementView" text="Measurement"/>
-                                <MenuItem mnemonicParsing="false" onAction="#openThrombectomyView" text="Thrombectomy"/>
-                                <MenuItem mnemonicParsing="false" onAction="#openAutoTrackView" text="AutoTrack" />
-                            </items>
-                        </Menu>
-                    </items>
-                </Menu>
-                <Menu mnemonicParsing="false" text="Help">
-                    <items>
-                        <MenuItem mnemonicParsing="false" onAction="#openAboutView" text="About"/>
-                    </items>
-                </Menu>
-            </menus>
+            </Menu>
+            <Menu mnemonicParsing="false" text="Help">
+                <MenuItem mnemonicParsing="false" onAction="#openAboutView" text="About"/>
+            </Menu>
         </MenuBar>
     </top>
     <center>
         <TabPane fx:id="tabPane">
-            <tabs>
-                <Tab closable="false" fx:id="trackingDataTab" text="Tracking Data Input" onSelectionChanged="#onChangeView">
-                    <content>
-                        <fx:include fx:id="trackingData" source="TrackingDataView.fxml"/>
-                    </content>
-                </Tab>
-                <Tab closable="false" text="Video Input">
-                    <content>
-                        <fx:include fx:id="video" source="VideoView.fxml"/>
-                    </content>
-                </Tab>
-                <Tab closable="false" fx:id="visualizationTab" text="Visualization" onSelectionChanged="#onChangeView">
-                    <content>
-                        <fx:include fx:id="visualization" source="VisualizationView.fxml"/>
-                    </content>
-                </Tab>
-            </tabs>
+            <Tab closable="false" fx:id="trackingDataTab" text="Tracking Data Input" onSelectionChanged="#onChangeView">
+                <fx:include fx:id="trackingData" source="TrackingDataView.fxml"/>
+            </Tab>
+            <Tab closable="false" text="Video Input">
+                <fx:include fx:id="video" source="VideoView.fxml"/>
+            </Tab>
+            <Tab closable="false" fx:id="visualizationTab" text="Visualization" onSelectionChanged="#onChangeView">
+                <fx:include fx:id="visualization" source="VisualizationView.fxml"/>
+            </Tab>
         </TabPane>
     </center>
     <bottom>
         <HBox maxHeight="20">
-            <children>
-                <Region HBox.hgrow="ALWAYS"/>
-                <Label fx:id="status" prefHeight="12.0" textAlignment="RIGHT" HBox.hgrow="ALWAYS">
-                    <padding>
-                        <Insets bottom="3.0" left="3.0" right="3.0" top="3.0"/>
-                    </padding>
-                </Label>
-            </children>
             <padding>
                 <Insets bottom="3.0" left="3.0" right="3.0" top="3.0"/>
             </padding>
+            <Region HBox.hgrow="ALWAYS"/>
+            <Label fx:id="status" prefHeight="12.0" textAlignment="RIGHT" HBox.hgrow="ALWAYS">
+                <padding>
+                    <Insets bottom="3.0" left="3.0" right="3.0" top="3.0"/>
+                </padding>
+            </Label>
         </HBox>
     </bottom>
 </BorderPane>

--- a/src/main/resources/view/SettingsView.fxml
+++ b/src/main/resources/view/SettingsView.fxml
@@ -26,7 +26,7 @@
                 <CheckBox fx:id="searchForMoreVideos" mnemonicParsing="false" onAction="#onSearchForMoreVideosClicked"
                           text="Search for more video devices"/>
 
-                <CheckBox fx:id="Vertical Fieldgenerator" mnemonicParsing="false" onAction="#onVerticalFGClicked"
+                <CheckBox fx:id="verticalFG" mnemonicParsing="false" onAction="#onVerticalFGClicked"
                           text="2d transform: replace y by z"/>
             </VBox>
         </TitledPane>

--- a/src/main/resources/view/SettingsView.fxml
+++ b/src/main/resources/view/SettingsView.fxml
@@ -6,6 +6,8 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.Label?>
 <HBox spacing="40.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.SettingsController">
     <padding>
         <Insets bottom="30.0" left="30.0" right="30.0" top="30.0" />
@@ -19,6 +21,19 @@
          <VBox.margin>
             <Insets />
          </VBox.margin>
+        </TitledPane>
+
+        <TitledPane text="Videoinput">
+            <VBox spacing="10" >
+                <HBox spacing="20" alignment="CENTER_LEFT">
+                    <Label text="Video width"/>
+                    <TextField fx:id="videoWidth" prefWidth="50.0"/>
+                </HBox>
+                <HBox spacing="20" alignment="CENTER_LEFT">
+                    <Label text="Video height"/>
+                    <TextField fx:id="videoHeight" prefWidth="50.0" />
+                </HBox>
+            </VBox>
         </TitledPane>
 
         <TitledPane text="Autotrack">

--- a/src/main/resources/view/SettingsView.fxml
+++ b/src/main/resources/view/SettingsView.fxml
@@ -22,9 +22,12 @@
         </TitledPane>
 
         <TitledPane text="Autotrack">
-            <VBox>
+            <VBox spacing="20">
                 <CheckBox fx:id="searchForMoreVideos" mnemonicParsing="false" onAction="#onSearchForMoreVideosClicked"
                           text="Search for more video devices"/>
+
+                <CheckBox fx:id="exchangeYZ" mnemonicParsing="false" onAction="#onExchangeYZClicked"
+                          text="2d transform: replace y by z"/>
             </VBox>
         </TitledPane>
     </VBox>

--- a/src/main/resources/view/SettingsView.fxml
+++ b/src/main/resources/view/SettingsView.fxml
@@ -2,26 +2,30 @@
 
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.control.ListView?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
 
-
-<HBox spacing="40.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
-      fx:controller="controller.SettingsController">
+<HBox spacing="40.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.SettingsController">
     <padding>
-        <Insets bottom="30.0" left="30.0" right="30.0" top="30.0"/>
+        <Insets bottom="30.0" left="30.0" right="30.0" top="30.0" />
     </padding>
-    <ListView fx:id="listView" minWidth="100"/>
-    <GridPane minWidth="100">
-        <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" minWidth="100.0"/>
-        </columnConstraints>
-        <rowConstraints>
-            <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-        </rowConstraints>
-        <CheckBox fx:id="consoleOutput" mnemonicParsing="false" onAction="#changeConsoleOutput" text="Console Output"/>
-    </GridPane>
+    <VBox spacing="20">
+        <TitledPane text="Logging">
+            <VBox>
+                <CheckBox fx:id="consoleOutput" mnemonicParsing="false" onAction="#changeConsoleOutput"
+                          text="Log to console"/>
+            </VBox>
+         <VBox.margin>
+            <Insets />
+         </VBox.margin>
+        </TitledPane>
+
+        <TitledPane text="Autotrack">
+            <VBox>
+                <CheckBox fx:id="searchForMoreVideos" mnemonicParsing="false" onAction="#onSearchForMoreVideosClicked"
+                          text="Search for more video devices"/>
+            </VBox>
+        </TitledPane>
+    </VBox>
 </HBox>

--- a/src/main/resources/view/SettingsView.fxml
+++ b/src/main/resources/view/SettingsView.fxml
@@ -26,7 +26,7 @@
                 <CheckBox fx:id="searchForMoreVideos" mnemonicParsing="false" onAction="#onSearchForMoreVideosClicked"
                           text="Search for more video devices"/>
 
-                <CheckBox fx:id="exchangeYZ" mnemonicParsing="false" onAction="#onExchangeYZClicked"
+                <CheckBox fx:id="Vertical Fieldgenerator" mnemonicParsing="false" onAction="#onVerticalFGClicked"
                           text="2d transform: replace y by z"/>
             </VBox>
         </TitledPane>

--- a/src/main/resources/view/ThrombectomyView.fxml
+++ b/src/main/resources/view/ThrombectomyView.fxml
@@ -10,70 +10,83 @@
 <?import userinterface.ImageScatterChart?>
 <?import javafx.scene.control.ScrollPane?>
 
-<ScrollPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.ThrombectomyController">
-<content>
-<AnchorPane>
-   <children>
-      <VBox prefHeight="652.0" prefWidth="432.0">
-         <children>
-         	<ImageScatterChart fx:id="chartCoronal" horizontalGridLinesVisible="false" horizontalZeroLineVisible="false" prefHeight="300" prefWidth="400" title="Coronal" verticalGridLinesVisible="false" verticalZeroLineVisible="false">
-				<xAxis>
-         			<NumberAxis autoRanging="false" forceZeroInRange="false" label="X" lowerBound="-100" minorTickCount="0" minorTickVisible="false" side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" upperBound="182.5" />
-         		</xAxis>
-         		<yAxis>
-         			<NumberAxis autoRanging="false" forceZeroInRange="false" label="Y" lowerBound="-100" minorTickCount="0" minorTickVisible="false" side="LEFT" tickLabelsVisible="false" tickMarkVisible="false" upperBound="106" />
-         		</yAxis>
-         	</ImageScatterChart>
-         	<ImageScatterChart fx:id="chartAxial" horizontalGridLinesVisible="false" horizontalZeroLineVisible="false" prefHeight="300" prefWidth="400" title="Axial" verticalGridLinesVisible="false" verticalZeroLineVisible="false">
-         		<xAxis>
-                        <NumberAxis autoRanging="false" forceZeroInRange="false" label="X" lowerBound="-100" minorTickCount="0" minorTickVisible="false" side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" upperBound="82.5" />
-         		</xAxis>
-         		<yAxis>
-         			<NumberAxis autoRanging="false" forceZeroInRange="false" label="Z" lowerBound="200" minorTickCount="0" minorTickVisible="false" side="LEFT" tickLabelsVisible="false" tickMarkVisible="false" upperBound="306" />
-         		</yAxis>
-         	</ImageScatterChart>
-         </children>
-      </VBox>
-      <VBox layoutX="412.0" layoutY="2.0" prefHeight="665.0" prefWidth="408.0">
-         <children>
-			<ImageScatterChart fx:id="chartSagittal" horizontalGridLinesVisible="false" horizontalZeroLineVisible="false" prefHeight="300" prefWidth="400" title="Sagittal" verticalGridLinesVisible="false" verticalZeroLineVisible="false">
+<ScrollPane xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="controller.ThrombectomyController">
+    <AnchorPane>
+        <VBox prefHeight="652.0" prefWidth="432.0">
+            <ImageScatterChart fx:id="chartCoronal" horizontalGridLinesVisible="false"
+                               horizontalZeroLineVisible="false" prefHeight="300" prefWidth="400"
+                               title="Coronal" verticalGridLinesVisible="false" verticalZeroLineVisible="false">
                 <xAxis>
-         			<NumberAxis autoRanging="false" forceZeroInRange="false" label="Z" lowerBound="200" minorTickCount="0" minorTickVisible="false" side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" upperBound="382.5" />
-         		</xAxis>
-         		<yAxis>
-         			<NumberAxis autoRanging="false" forceZeroInRange="false" label="Y" lowerBound="-100" minorTickCount="0" minorTickVisible="false" side="LEFT" tickLabelsVisible="false" tickMarkVisible="false" upperBound="106" />
-         		</yAxis>
-         	</ImageScatterChart>
+                    <NumberAxis autoRanging="false" forceZeroInRange="false" label="X" lowerBound="-100"
+                                minorTickCount="0" minorTickVisible="false" side="BOTTOM"
+                                tickLabelsVisible="false" tickMarkVisible="false" upperBound="182.5"/>
+                </xAxis>
+                <yAxis>
+                    <NumberAxis autoRanging="false" forceZeroInRange="false" label="Y" lowerBound="-100"
+                                minorTickCount="0" minorTickVisible="false" side="LEFT"
+                                tickLabelsVisible="false" tickMarkVisible="false" upperBound="106"/>
+                </yAxis>
+            </ImageScatterChart>
+            <ImageScatterChart fx:id="chartAxial" horizontalGridLinesVisible="false"
+                               horizontalZeroLineVisible="false" prefHeight="300" prefWidth="400" title="Axial"
+                               verticalGridLinesVisible="false" verticalZeroLineVisible="false">
+                <xAxis>
+                    <NumberAxis autoRanging="false" forceZeroInRange="false" label="X" lowerBound="-100"
+                                minorTickCount="0" minorTickVisible="false" side="BOTTOM"
+                                tickLabelsVisible="false" tickMarkVisible="false" upperBound="82.5"/>
+                </xAxis>
+                <yAxis>
+                    <NumberAxis autoRanging="false" forceZeroInRange="false" label="Z" lowerBound="200"
+                                minorTickCount="0" minorTickVisible="false" side="LEFT"
+                                tickLabelsVisible="false" tickMarkVisible="false" upperBound="306"/>
+                </yAxis>
+            </ImageScatterChart>
+        </VBox>
+        <VBox layoutX="412.0" layoutY="2.0" prefHeight="665.0" prefWidth="408.0">
+            <ImageScatterChart fx:id="chartSagittal" horizontalGridLinesVisible="false"
+                               horizontalZeroLineVisible="false" prefHeight="300" prefWidth="400"
+                               title="Sagittal" verticalGridLinesVisible="false"
+                               verticalZeroLineVisible="false">
+                <xAxis>
+                    <NumberAxis autoRanging="false" forceZeroInRange="false" label="Z" lowerBound="200"
+                                minorTickCount="0" minorTickVisible="false" side="BOTTOM"
+                                tickLabelsVisible="false" tickMarkVisible="false" upperBound="382.5"/>
+                </xAxis>
+                <yAxis>
+                    <NumberAxis autoRanging="false" forceZeroInRange="false" label="Y" lowerBound="-100"
+                                minorTickCount="0" minorTickVisible="false" side="LEFT"
+                                tickLabelsVisible="false" tickMarkVisible="false" upperBound="106"/>
+                </yAxis>
+            </ImageScatterChart>
             <AnchorPane fx:id="positionDetailBox" prefHeight="360.0" prefWidth="408.0" visible="false">
-               <children>
-                  <Label fx:id="imageLabel" layoutX="21.0" layoutY="6.0" style="-fx-font-weight: bold;" />
-                  <Label layoutX="31.0" layoutY="49.0" text="X-Value:" />
-                  <Button fx:id="setPositionBtn" layoutX="271.0" layoutY="180.0" mnemonicParsing="false" text="Set Position" />
-                  <Label layoutX="31.0" layoutY="79.0" text="Y-Value:" />
-                  <Label layoutX="41.0" layoutY="114.0" text="Scale:" />
-                  <TextField fx:id="imageXValue" layoutX="96.0" layoutY="45.0" />
-                  <TextField fx:id="imageYValue" layoutX="96.0" layoutY="75.0" />
-                  <TextField fx:id="imageScale" layoutX="96.0" layoutY="110.0" />
-               </children>
+                <children>
+                    <Label fx:id="imageLabel" layoutX="21.0" layoutY="6.0" style="-fx-font-weight: bold;"/>
+                    <Label layoutX="31.0" layoutY="49.0" text="X-Value:"/>
+                    <Button fx:id="setPositionBtn" layoutX="271.0" layoutY="180.0" mnemonicParsing="false"
+                            text="Set Position"/>
+                    <Label layoutX="31.0" layoutY="79.0" text="Y-Value:"/>
+                    <Label layoutX="41.0" layoutY="114.0" text="Scale:"/>
+                    <TextField fx:id="imageXValue" layoutX="96.0" layoutY="45.0"/>
+                    <TextField fx:id="imageYValue" layoutX="96.0" layoutY="75.0"/>
+                    <TextField fx:id="imageScale" layoutX="96.0" layoutY="110.0"/>
+                </children>
             </AnchorPane>
-         </children>
-      </VBox>
-      <VBox layoutX="820.0" layoutY="25.0" prefHeight="115.0" prefWidth="134.0" spacing="5.0" style="-fx-background-color: lightblue;">
-         <children>
-            <Label text="Select Image:" />
-            <Button fx:id="loadCoronalBtn" mnemonicParsing="false" onAction="#loadFile" text="Coronal" />
-            <Button fx:id="loadSagittalBtn" mnemonicParsing="false" onAction="#loadFile" text="Sagittal" />
-            <Button fx:id="loadAxialBtn" mnemonicParsing="false" onAction="#loadFile" text="Axial" />
-         </children>
-         <opaqueInsets>
-            <Insets bottom="5.0" />
-         </opaqueInsets>
-         <padding>
-            <Insets bottom="5.0" left="4.0" right="5.0" top="5.0" />
-         </padding>
-      </VBox>
-      <Button layoutX="820.0" layoutY="169.0" mnemonicParsing="false" text="Show Tracking Data" onAction="#showTrackingData" />
-   </children>
-</AnchorPane>
-</content>
+        </VBox>
+        <VBox layoutX="820.0" layoutY="25.0" prefHeight="115.0" prefWidth="134.0" spacing="5.0"
+              style="-fx-background-color: lightblue;">
+            <opaqueInsets>
+                <Insets bottom="5.0"/>
+            </opaqueInsets>
+            <padding>
+                <Insets bottom="5.0" left="4.0" right="5.0" top="5.0"/>
+            </padding>
+            <Label text="Select Image:"/>
+            <Button fx:id="loadCoronalBtn" mnemonicParsing="false" onAction="#loadFile" text="Coronal"/>
+            <Button fx:id="loadSagittalBtn" mnemonicParsing="false" onAction="#loadFile" text="Sagittal"/>
+            <Button fx:id="loadAxialBtn" mnemonicParsing="false" onAction="#loadFile" text="Axial"/>
+        </VBox>
+        <Button layoutX="820.0" layoutY="169.0" mnemonicParsing="false" text="Show Tracking Data"
+                onAction="#showTrackingData"/>
+    </AnchorPane>
 </ScrollPane>

--- a/src/main/resources/view/TrackingDataView.fxml
+++ b/src/main/resources/view/TrackingDataView.fxml
@@ -17,90 +17,94 @@
 <?import javafx.scene.layout.TilePane?>
 <?import javafx.scene.layout.VBox?>
 
-<ScrollPane fx:id="scrollPane" fitToWidth="true" hbarPolicy="NEVER" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.TrackingDataController">   	<VBox maxHeight="Infinity" maxWidth="Infinity">
+<ScrollPane fx:id="scrollPane" fitToWidth="true" hbarPolicy="NEVER" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.TrackingDataController">
+	<VBox maxHeight="Infinity" maxWidth="Infinity">
    		<VBox alignment="CENTER" maxHeight="Infinity" maxWidth="Infinity">
 			<VBox.margin>
 				<Insets left="50.0" right="50.0" />
 			</VBox.margin>
-         <TilePane alignment="CENTER" hgap="20.0" prefColumns="2" prefRows="2" prefTileHeight="350.0" prefTileWidth="350.0" vgap="10.0" VBox.vgrow="ALWAYS">
-            <children>
-   				<ScatterChart fx:id="s1" title="XY-Plane">
-   					<xAxis>
-   						<NumberAxis autoRanging="false" label="X" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0" upperBound="500.0" />
-   					</xAxis>
-   					<yAxis>
-   						<NumberAxis autoRanging="false" label="Y" lowerBound="-500.0" minorTickVisible="false" side="LEFT" tickUnit="100.0" upperBound="500.0" />
-   					</yAxis>
-   				</ScatterChart>
-   				<ScatterChart fx:id="s2" title="ZY-Plane">
-   					<xAxis>
-   						<NumberAxis autoRanging="false" label="Z" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0" upperBound="500.0" />
-   					</xAxis>
-   					<yAxis>
-   						<NumberAxis autoRanging="false" label="Y" lowerBound="-500.0" side="LEFT" tickUnit="100.0" upperBound="500.0" />
-   					</yAxis>
-   				</ScatterChart>
-   				<ScatterChart fx:id="s3" title="XZ-Plane">
-   					<xAxis>
-   						<NumberAxis autoRanging="false" label="X" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0" upperBound="500.0" />
-   					</xAxis>
-   					<yAxis>
-   						<NumberAxis autoRanging="false" label="Z" lowerBound="-500.0" side="LEFT" tickUnit="100.0" upperBound="500.0" />
-   					</yAxis>
-   				</ScatterChart>
-               <VBox>
-                  <children>
-      						<AnchorPane prefHeight="266.0" prefWidth="350.0">
-      							<children>
-      								<Group fx:id="meshGroup" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-      							</children>
-      						</AnchorPane>
-         				<GridPane alignment="CENTER" prefHeight="86.0" prefWidth="350.0">
-         					<columnConstraints>
-         						<ColumnConstraints hgrow="SOMETIMES" />
-                           <ColumnConstraints hgrow="SOMETIMES" />
-         					</columnConstraints>
-         					<rowConstraints>
-         						<RowConstraints minHeight="10.0" percentHeight="77.0" vgrow="SOMETIMES" />
-         					</rowConstraints>
-         					<children>
-         						<VBox fx:id="posBox" alignment="TOP_CENTER">
-         							<Label text="Position" />
-         						</VBox>
-         						<VBox fx:id="rotBox" alignment="TOP_CENTER" GridPane.columnIndex="1">
-         							<Label text="Rotation" />
-         						</VBox>
-         					</children>
-         				</GridPane>
-                  </children>
-               </VBox>
-            </children>
-         </TilePane>
-         <GridPane alignment="CENTER" hgap="10.0" vgap="10.0">
-            <VBox.margin>
-               <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-            </VBox.margin>
-            <columnConstraints>
-               <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" />
-               <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-            </columnConstraints>
-            <rowConstraints>
-               <RowConstraints minHeight="10.0" prefHeight="30.0" valignment="CENTER" vgrow="SOMETIMES" />
-               <RowConstraints minHeight="10.0" valignment="CENTER" vgrow="SOMETIMES" />
-            </rowConstraints>
-            <children>
+			<TilePane alignment="CENTER" hgap="20.0" prefColumns="2" prefRows="2" prefTileHeight="350.0"
+					  prefTileWidth="350.0" vgap="10.0" VBox.vgrow="ALWAYS">
+				<ScatterChart fx:id="s1" title="XY-Plane">
+					<xAxis>
+						<NumberAxis autoRanging="false" label="X" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0"
+									upperBound="500.0"/>
+					</xAxis>
+					<yAxis>
+						<NumberAxis autoRanging="false" label="Y" lowerBound="-500.0" minorTickVisible="false"
+									side="LEFT" tickUnit="100.0" upperBound="500.0"/>
+					</yAxis>
+				</ScatterChart>
+				<ScatterChart fx:id="s2" title="ZY-Plane">
+					<xAxis>
+						<NumberAxis autoRanging="false" label="Z" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0"
+									upperBound="500.0"/>
+					</xAxis>
+					<yAxis>
+						<NumberAxis autoRanging="false" label="Y" lowerBound="-500.0" side="LEFT" tickUnit="100.0"
+									upperBound="500.0"/>
+					</yAxis>
+				</ScatterChart>
+				<ScatterChart fx:id="s3" title="XZ-Plane">
+					<xAxis>
+						<NumberAxis autoRanging="false" label="X" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0"
+									upperBound="500.0"/>
+					</xAxis>
+					<yAxis>
+						<NumberAxis autoRanging="false" label="Z" lowerBound="-500.0" side="LEFT" tickUnit="100.0"
+									upperBound="500.0"/>
+					</yAxis>
+				</ScatterChart>
+				<VBox>
+					<AnchorPane prefHeight="266.0" prefWidth="350.0">
+						<Group fx:id="meshGroup" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0"
+							   AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0"/>
+					</AnchorPane>
+					<GridPane alignment="CENTER" prefHeight="86.0" prefWidth="350.0">
+						<columnConstraints>
+							<ColumnConstraints hgrow="SOMETIMES"/>
+							<ColumnConstraints hgrow="SOMETIMES"/>
+						</columnConstraints>
+						<rowConstraints>
+							<RowConstraints minHeight="10.0" percentHeight="77.0" vgrow="SOMETIMES"/>
+						</rowConstraints>
+						<VBox fx:id="posBox" alignment="TOP_CENTER">
+							<Label text="Position"/>
+						</VBox>
+						<VBox fx:id="rotBox" alignment="TOP_CENTER" GridPane.columnIndex="1">
+							<Label text="Rotation"/>
+						</VBox>
+					</GridPane>
+				</VBox>
+			</TilePane>
+			<GridPane alignment="CENTER" hgap="10.0" vgap="10.0">
+				<VBox.margin>
+					<Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+				</VBox.margin>
+				<columnConstraints>
+					<ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0"/>
+					<ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0"/>
+				</columnConstraints>
+				<rowConstraints>
+					<RowConstraints minHeight="10.0" prefHeight="30.0" valignment="CENTER" vgrow="SOMETIMES"/>
+					<RowConstraints minHeight="10.0" valignment="CENTER" vgrow="SOMETIMES"/>
+				</rowConstraints>
 				<HBox alignment="CENTER">
-					<ToggleButton mnemonicParsing="false" onAction="#onConnectButtonClicked" styleClass="green-toggle-button" text="Connect via OpenIGTLink (localhost)">
-				 <graphic>
-							<ProgressIndicator fx:id="connectionIndicator" maxHeight="25.0" maxWidth="25.0" visible="false" />
-				 </graphic>
-			  </ToggleButton>
+					<ToggleButton mnemonicParsing="false" onAction="#onConnectButtonClicked"
+								  styleClass="green-toggle-button" text="Connect via OpenIGTLink (localhost)">
+						<graphic>
+							<ProgressIndicator fx:id="connectionIndicator" maxHeight="25.0" maxWidth="25.0"
+											   visible="false"/>
+						</graphic>
+					</ToggleButton>
 				</HBox>
-				<Button fx:id="loadCSVBtn" alignment="CENTER" mnemonicParsing="false" onAction="#loadCSVFile" text="Load CSV" GridPane.columnIndex="1" />
-				<Button fx:id="visualizeTrackingBtn" alignment="CENTER" mnemonicParsing="false" onAction="#visualizeTracking" text="Start Tracking and Visualization" GridPane.rowIndex="1" />
-				<ToggleButton fx:id="freezeTglBtn" mnemonicParsing="false" onAction="#freezeVisualization" text="Freeze / Unfreeze" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-            </children>
-         </GridPane>
+				<Button fx:id="loadCSVBtn" alignment="CENTER" mnemonicParsing="false" onAction="#loadCSVFile"
+						text="Load CSV" GridPane.columnIndex="1"/>
+				<Button fx:id="visualizeTrackingBtn" alignment="CENTER" mnemonicParsing="false"
+						onAction="#visualizeTracking" text="Start Tracking and Visualization" GridPane.rowIndex="1"/>
+				<ToggleButton fx:id="freezeTglBtn" mnemonicParsing="false" onAction="#freezeVisualization"
+							  text="Freeze / Unfreeze" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+			</GridPane>
    		</VBox>
       <padding>
          <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/src/main/resources/view/TrackingDataView.fxml
+++ b/src/main/resources/view/TrackingDataView.fxml
@@ -35,19 +35,19 @@
 									side="LEFT" tickUnit="100.0" upperBound="500.0"/>
 					</yAxis>
 				</ScatterChart>
-				<ScatterChart fx:id="s2" title="ZY-Plane">
+				<ScatterChart fx:id="s2" title="ZX-Plane">
 					<xAxis>
 						<NumberAxis autoRanging="false" label="Z" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0"
 									upperBound="500.0"/>
 					</xAxis>
 					<yAxis>
-						<NumberAxis autoRanging="false" label="Y" lowerBound="-500.0" side="LEFT" tickUnit="100.0"
+						<NumberAxis autoRanging="false" label="X" lowerBound="-500.0" side="LEFT" tickUnit="100.0"
 									upperBound="500.0"/>
 					</yAxis>
 				</ScatterChart>
-				<ScatterChart fx:id="s3" title="XZ-Plane">
+				<ScatterChart fx:id="s3" title="YZ-Plane">
 					<xAxis>
-						<NumberAxis autoRanging="false" label="X" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0"
+						<NumberAxis autoRanging="false" label="Y" lowerBound="-500.0" side="BOTTOM" tickUnit="100.0"
 									upperBound="500.0"/>
 					</xAxis>
 					<yAxis>

--- a/src/main/resources/view/VisualizationView.fxml
+++ b/src/main/resources/view/VisualizationView.fxml
@@ -19,80 +19,76 @@
 <?import javafx.scene.paint.Color?>
 
 <ScrollPane fx:id="scrollPane" fitToWidth="true" hbarPolicy="NEVER" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="controller.VisualizationController">    <content>
-        <VBox maxHeight="Infinity" maxWidth="Infinity">
-            <padding>
-                <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-            </padding>
-            <children>
-                <VBox alignment="CENTER" maxHeight="Infinity" maxWidth="Infinity">
-                    <VBox.margin>
-                        <Insets left="50.0" right="50.0" />
-                    </VBox.margin>
-                    <children>
-                        <TilePane alignment="CENTER" hgap="20.0" prefColumns="1" prefRows="1" prefTileHeight="710.0" prefTileWidth="720.0" vgap="10.0" VBox.vgrow="ALWAYS">
-                            <children>
-                                <VBox>
-                                    <children>
-                                        <AnchorPane minHeight="600.0" minWidth="800.0">
-                                            <children>
-                                                <Group fx:id="meshGroup" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
-                                            </children>
-                                        </AnchorPane>
-                              <ToolBar pickOnBounds="false">
-                                <items>
-                                    <ButtonBar prefWidth="200.0">
-                                       <buttons>
-                                          <Label text="Tracker Size:" />
-                                                    <Slider fx:id="trackerSlider" blockIncrement="1.0" majorTickUnit="1.0" max="20.0" min="1.0" minorTickCount="0" onMouseDragged="#setTrackerSize" value="10.0" />
-                                       </buttons>
-                                    </ButtonBar>
-                                    <ButtonBar prefWidth="200.0">
-                                       <buttons>
-                                          <Label text="Tracker Color:" />
-                                                    <ColorPicker fx:id="colorPicker" onAction="#setTrackerColor">
-                                             <value>
-                                                <Color red="1.0" />
-                                             </value>
-                                          </ColorPicker>
-                                       </buttons>
-                                    </ButtonBar>
-                                    <ButtonBar prefWidth="375.0">
-                                       <buttons>
-                                          <Label text="3D-Model:" />
-                                          <ToggleButton fx:id="cullBack" mnemonicParsing="false" onAction="#toggleCullFace" text="Cull Back" />
-                                          <ToggleButton fx:id="wireframe" mnemonicParsing="false" onAction="#toggleWireframe" text="Wireframe" />
-                                       </buttons>
-                                    </ButtonBar>
-                                </items>
-                              </ToolBar>
-                                    </children>
-                                </VBox>
-                            </children>
-                        </TilePane>
-                        <GridPane hgap="10.0" vgap="10.0">
-                            <columnConstraints>
-                                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                            </columnConstraints>
-                            <rowConstraints>
-                                <RowConstraints maxHeight="45.0" minHeight="9.0" prefHeight="28.0" vgrow="SOMETIMES" />
-                            </rowConstraints>
-                            <children>
-                                <AnchorPane>
-                                    <children>
-                                        <Button fx:id="start" layoutX="128.0" layoutY="2.0" mnemonicParsing="false" onAction="#startTracking" text="Start" AnchorPane.leftAnchor="128.0" AnchorPane.topAnchor="2.0" />
-                                        <ToggleButton fx:id="pause" layoutX="173.0" layoutY="2.0" mnemonicParsing="false" onAction="#pauseVisualization" text="Pause" AnchorPane.leftAnchor="173.0" AnchorPane.topAnchor="2.0" />
-                                    </children>
-                                </AnchorPane>
-                                <Button fx:id="loadStlFile" mnemonicParsing="false" onAction="#loadSTLFile" text="Load STL" GridPane.columnIndex="1" GridPane.halignment="CENTER" />
-                            </children>
-                            <VBox.margin>
-                                <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-                            </VBox.margin>
-                        </GridPane>
-                    </children>
+    <VBox maxHeight="Infinity" maxWidth="Infinity">
+        <padding>
+            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+        </padding>
+        <VBox alignment="CENTER" maxHeight="Infinity" maxWidth="Infinity">
+            <VBox.margin>
+                <Insets left="50.0" right="50.0"/>
+            </VBox.margin>
+            <TilePane alignment="CENTER" hgap="20.0" prefColumns="1" prefRows="1" prefTileHeight="710.0"
+                      prefTileWidth="720.0" vgap="10.0" VBox.vgrow="ALWAYS">
+                <VBox>
+                    <AnchorPane minHeight="600.0" minWidth="800.0">
+                        <Group fx:id="meshGroup" AnchorPane.bottomAnchor="0.0"
+                               AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0"
+                               AnchorPane.topAnchor="0.0"/>
+                    </AnchorPane>
+                    <ToolBar pickOnBounds="false">
+                        <ButtonBar prefWidth="200.0">
+                            <buttons>
+                                <Label text="Tracker Size:"/>
+                                <Slider fx:id="trackerSlider" blockIncrement="1.0" majorTickUnit="1.0"
+                                        max="20.0" min="1.0" minorTickCount="0"
+                                        onMouseDragged="#setTrackerSize" value="10.0"/>
+                            </buttons>
+                        </ButtonBar>
+                        <ButtonBar prefWidth="200.0">
+                            <buttons>
+                                <Label text="Tracker Color:"/>
+                                <ColorPicker fx:id="colorPicker" onAction="#setTrackerColor">
+                                    <value>
+                                        <Color red="1.0"/>
+                                    </value>
+                                </ColorPicker>
+                            </buttons>
+                        </ButtonBar>
+                        <ButtonBar prefWidth="375.0">
+                            <buttons>
+                                <Label text="3D-Model:"/>
+                                <ToggleButton fx:id="cullBack" mnemonicParsing="false"
+                                              onAction="#toggleCullFace" text="Cull Back"/>
+                                <ToggleButton fx:id="wireframe" mnemonicParsing="false"
+                                              onAction="#toggleWireframe" text="Wireframe"/>
+                            </buttons>
+                        </ButtonBar>
+                    </ToolBar>
                 </VBox>
-            </children>
+            </TilePane>
+            <GridPane hgap="10.0" vgap="10.0">
+                <columnConstraints>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0"/>
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0"/>
+                </columnConstraints>
+                <rowConstraints>
+                    <RowConstraints maxHeight="45.0" minHeight="9.0" prefHeight="28.0" vgrow="SOMETIMES"/>
+                </rowConstraints>
+                <VBox.margin>
+                    <Insets bottom="10.0" left="10.0" right="10.0" top="10.0"/>
+                </VBox.margin>
+                <AnchorPane>
+                    <Button fx:id="start" layoutX="128.0" layoutY="2.0" mnemonicParsing="false"
+                            onAction="#startTracking" text="Start" AnchorPane.leftAnchor="128.0"
+                            AnchorPane.topAnchor="2.0"/>
+                    <ToggleButton fx:id="pause" layoutX="173.0" layoutY="2.0" mnemonicParsing="false"
+                                  onAction="#pauseVisualization" text="Pause" AnchorPane.leftAnchor="173.0"
+                                  AnchorPane.topAnchor="2.0"/>
+                </AnchorPane>
+                <Button fx:id="loadStlFile" mnemonicParsing="false" onAction="#loadSTLFile" text="Load STL"
+                        GridPane.columnIndex="1" GridPane.halignment="CENTER"/>
+            </GridPane>
         </VBox>
+    </VBox>
     </content>
 </ScrollPane>

--- a/src/test/java/inputOutput/LivestreamConnectionTest.java
+++ b/src/test/java/inputOutput/LivestreamConnectionTest.java
@@ -17,7 +17,7 @@ class LivestreamConnectionTest {
      */
     @Test
     void testObject() {
-        LivestreamSource livestream = new LivestreamSource(0);
+        LivestreamSource livestream = LivestreamSource.forDevice(0);
         assertNotNull(livestream);
     }
 
@@ -29,7 +29,7 @@ class LivestreamConnectionTest {
      */
     @Test
     void testOpenConnection() {
-        LivestreamSource livestream = new LivestreamSource(0);
+        LivestreamSource livestream = LivestreamSource.forDevice(0);
         assertTrue(livestream.openConnection());
     }
 
@@ -39,7 +39,7 @@ class LivestreamConnectionTest {
      */
     @Test
     void testCloseConnection() {
-        LivestreamSource livestream = new LivestreamSource(0);
+        LivestreamSource livestream = LivestreamSource.forDevice(0);
         livestream.openConnection();
         assertTrue(livestream.closeConnection());
     }

--- a/src/test/java/inputOutput/LivestreamSourceTransmissionTest.java
+++ b/src/test/java/inputOutput/LivestreamSourceTransmissionTest.java
@@ -22,7 +22,7 @@ class LivestreamSourceTransmissionTest {
      */
     @BeforeEach
     void open() {
-        livestream = new LivestreamSource(0);
+        livestream = LivestreamSource.forDevice(0);
         livestream.openConnection();
     }
 

--- a/src/test/java/inputOutput/TestFrame.java
+++ b/src/test/java/inputOutput/TestFrame.java
@@ -76,7 +76,7 @@ public class TestFrame extends JFrame implements ActionListener {
         Object src = e.getSource();
         // The datatransport starts after user interaction
         if (src == startLive) {
-            LivestreamSource liveStream = new LivestreamSource(0);
+            LivestreamSource liveStream = LivestreamSource.forDevice(0);
             imgSrc = liveStream;
             thread = new TestFrameThread(videoPanel, imgSrc);
         }


### PR DESCRIPTION
This PR introduces fixes to bugs with autotrack along with a new settings view and new options.

- Fix error that occured when last file location isn't available anymore (e.g. because of the use of removable media)
- Fix error when Autotrack and Video view are opened at the same time => Now all video connections to devices are shared across the application (which can also be handy laterwards)
- Fixes multiple small issues
- Temporarily removed sensor curve visualization, as it needs further work 
- Add new settings view
- Add new option to enable exhaustive video device search for autotrack
- Increase camera resolution up to 1920x1080
- Add option to exchange x by z when using 2D transformations in Autotrack
- Customize video resolution by using a new setting, also downsample (or upsample even) the image if it does not meet this constraint (fixes issue with video devices that do not support lower resolutions)
- Fixed incorrectly labeled diagrams in the TrackingView [severe!]
- Slightly improved performance of autotrack by caching the transformation matrix