### PR TITLE
Add executable creation task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ plugins {
 
     // Spotbugs is a static analyzer for java
     id 'com.github.spotbugs' version '6.0.7'
+
+    // With this plugin, we can build a Windows executable
+    id 'edu.sc.seis.launch4j' version '3.0.5'
 }
 
 javafx {
@@ -97,4 +100,8 @@ spotbugsMain {
             stylesheet = 'fancy-hist.xsl'
         }
     }
+}
+
+launch4j {
+    mainClassName = 'mainMethod.StartClass'
 }


### PR DESCRIPTION
This adds a gradle task with which we can easily create a portable executable file out of the current project version.
Only requirement is that the machine this is deployed to has a matching version of Java installed.